### PR TITLE
Prevent autocomplete and set "click|once"

### DIFF
--- a/Frontend/src/components/TableEditors/Customers/EditCustomerPopup.svelte
+++ b/Frontend/src/components/TableEditors/Customers/EditCustomerPopup.svelte
@@ -132,6 +132,7 @@
             type="text"
             id="firstname"
             name="firstname"
+            autocomplete="off"
             bind:value={doc.firstname} />
         </div>
       </row>
@@ -142,6 +143,7 @@
             type="text"
             id="lastname"
             name="lastname"
+            autocomplete="off"
             bind:value={doc.lastname} />
         </div>
         <row />
@@ -159,6 +161,7 @@
             type="text"
             id="street"
             name="street"
+            autocomplete="off"
             bind:value={doc.street} />
         </div>
       </row>
@@ -171,6 +174,7 @@
             type="text"
             id="house_number"
             name="house_number"
+            autocomplete="off"
             bind:value={doc.house_number} />
         </div>
       </row>
@@ -202,7 +206,12 @@
       <row>
         <div class="col-label"><label for="email">E-Mail</label></div>
         <div class="col-input">
-          <input type="text" id="email" name="email" bind:value={doc.email} />
+          <input
+            type="text"
+            id="email"
+            name="email"
+            autocomplete="off"
+            bind:value={doc.email} />
         </div>
       </row>
       <row>
@@ -214,6 +223,7 @@
             type="text"
             id="telephone_number"
             name="telephone_number"
+            autocomplete="off"
             bind:value={doc.telephone_number} />
         </div>
       </row>
@@ -296,7 +306,7 @@
     {#if !createNew}
       <button
         class="button-delete"
-        on:click={() => {
+        on:click|once={() => {
           if (confirm('Soll dieser Kunde wirklich gelöscht werden?')) {
             $customerDb
               .removeDoc(doc)
@@ -309,6 +319,8 @@
           }
         }}>Kunde Löschen</button>
     {/if}
-    <button class="button-save" on:click={saveInDatabase}>Speichern</button>
+    <button
+      class="button-save"
+      on:click|once={saveInDatabase}>Speichern</button>
   </div>
 </div>

--- a/Frontend/src/components/TableEditors/Items/EditItemPopup.svelte
+++ b/Frontend/src/components/TableEditors/Items/EditItemPopup.svelte
@@ -197,6 +197,7 @@
             type="text"
             id="item_id"
             name="item_id"
+            autocomplete="off"
             value={doc._id}
             disabled />
         </div>
@@ -210,19 +211,30 @@
             type="text"
             id="item_name"
             name="item_name"
+            autocomplete="off"
             bind:value={doc.item_name} />
         </div>
       </row>
       <row>
         <div class="col-label"><label for="brand">Marke</label></div>
         <div class="col-input">
-          <input type="text" id="brand" name="brand" bind:value={doc.brand} />
+          <input
+            type="text"
+            id="brand"
+            name="brand"
+            autocomplete="off"
+            bind:value={doc.brand} />
         </div>
       </row>
       <row>
         <div class="col-label"><label for="itype">Typbezeichnung</label></div>
         <div class="col-input">
-          <input type="text" id="itype" name="itype" bind:value={doc.itype} />
+          <input
+            type="text"
+            id="itype"
+            name="itype"
+            autocomplete="off"
+            bind:value={doc.itype} />
         </div>
       </row>
     </InputGroup>
@@ -249,6 +261,7 @@
             type="text"
             id="deposit"
             name="deposit"
+            autocomplete="off"
             bind:value={doc.deposit} />
         </div>
       </row>
@@ -267,6 +280,7 @@
             type="text"
             id="properties"
             name="properties"
+            autocomplete="off"
             bind:value={doc.properties} />
         </div>
       </row>
@@ -279,7 +293,12 @@
       <row>
         <div class="col-label"><label for="parts">Anzahl Teile</label></div>
         <div class="col-input">
-          <input type="text" id="parts" name="parts" bind:value={doc.parts} />
+          <input
+            type="text"
+            id="parts"
+            name="parts"
+            autocomplete="off"
+            bind:value={doc.parts} />
         </div>
       </row>
       <row>
@@ -289,6 +308,7 @@
             type="text"
             id="manual"
             name="manual"
+            autocomplete="off"
             bind:value={doc.manual} />
         </div>
       </row>
@@ -299,6 +319,7 @@
             type="text"
             id="package"
             name="package"
+            autocomplete="off"
             bind:value={doc.package} />
         </div>
       </row>
@@ -311,7 +332,12 @@
       <row>
         <div class="col-label"><label for="image">Bild</label></div>
         <div class="col-input">
-          <input type="text" id="image" name="image" bind:value={doc.image} />
+          <input
+            type="text"
+            id="image"
+            name="image"
+            autocomplete="off"
+            bind:value={doc.image} />
         </div>
       </row>
     </InputGroup>
@@ -338,7 +364,7 @@
     {#if !createNew}
       <button
         class="button-delete"
-        on:click={() => {
+        on:click|once={() => {
           if (confirm('Soll dieser Gegenstand wirklich gelöscht werden?')) {
             $itemDb
               .removeDoc(doc)
@@ -353,6 +379,8 @@
         Gegenstand Löschen
       </button>
     {/if}
-    <button class="button-save" on:click={saveInDatabase}>Speichern</button>
+    <button
+      class="button-save"
+      on:click|once={saveInDatabase}>Speichern</button>
   </div>
 </div>

--- a/Frontend/src/components/TableEditors/Rentals/EditRentalPopup.svelte
+++ b/Frontend/src/components/TableEditors/Rentals/EditRentalPopup.svelte
@@ -396,6 +396,7 @@
             type="text"
             id="deposit"
             name="deposit"
+            autocomplete="off"
             bind:value={doc.deposit} />
         </div>
       </row>
@@ -408,6 +409,7 @@
             type="text"
             id="deposit_returned"
             name="deposit_returned"
+            autocomplete="off"
             bind:value={doc.deposit_returned} />
         </div>
       </row>
@@ -420,6 +422,7 @@
             type="text"
             id="deposit_retained"
             name="deposit_retained"
+            autocomplete="off"
             bind:value={doc.deposit_retained} />
         </div>
       </row>
@@ -432,6 +435,7 @@
             type="text"
             id="deposit_retainment_reason"
             name="deposit_retainment_reason"
+            autocomplete="off"
             bind:value={doc.deposit_retainment_reason} />
         </div>
       </row>
@@ -472,6 +476,7 @@
             type="text"
             id="remark"
             name="remark"
+            autocomplete="off"
             bind:value={doc.remark} />
         </div>
       </row>
@@ -483,7 +488,7 @@
     {#if !createNew}
       <button
         class="button-delete"
-        on:click={() => {
+        on:click|once={() => {
           if (confirm('Soll dieser Leihvorgang wirklich gelöscht werden?')) {
             $rentalDb
               .removeDoc(doc)
@@ -496,6 +501,8 @@
           }
         }}>Leihvorgang Löschen</button>
     {/if}
-    <button class="button-save" on:click={saveInDatabase}>Speichern</button>
+    <button
+      class="button-save"
+      on:click|once={saveInDatabase}>Speichern</button>
   </div>
 </div>


### PR DESCRIPTION
I've added autocomplete="off" to where applicable, additionally made the save/delete button a "click|once" instance, so that we prevent double clicks and double commits to the database

fix #93 