### PR TITLE
Address autocomplete: slow solution

### DIFF
--- a/Frontend/cypress/integration/customers.spec.js
+++ b/Frontend/cypress/integration/customers.spec.js
@@ -255,8 +255,10 @@ context("Customers", () => {
       cy.get("#telephone_number").type(newCustomer.telephone_number);
       cy.get("#subscribed_to_newsletter").click();
       cy.get("#street").type(newCustomer.street);
+      cy.get("body").click();
       cy.get("#house_number").type(newCustomer.house_number);
       cy.get("#postal_code").type(newCustomer.postal_code);
+      cy.get("body").click();
       cy.get("#city").type(newCustomer.city);
       cy.get("#remark").type(newCustomer.remark);
 

--- a/Frontend/src/components/Database/Database.js
+++ b/Frontend/src/components/Database/Database.js
@@ -202,8 +202,24 @@ class Database {
       limit: 10,
       fields: fields,
       selector: selector,
-    });
+    }); 
     return result.docs;
+  }
+
+  async fetchUniqueDocsBySelector(selector, fields) {
+    const result = await this.database.find({
+      limit: 9999,
+      fields: fields,
+      selector: selector,
+    });
+    const unique = [...new Set(result.docs.map(x => x[fields[0]]))];
+    const arr =  []
+    for (const val of unique) {
+      const obj = {}
+      obj[fields[0]] = val
+      arr.push(obj)
+  }
+    return arr;
   }
 
   selectorsForSearchTerm(searchTerm) {

--- a/Frontend/src/components/Database/Database.js
+++ b/Frontend/src/components/Database/Database.js
@@ -208,17 +208,23 @@ class Database {
 
   async fetchUniqueDocsBySelector(selector, fields) {
     const result = await this.database.find({
-      limit: 9999,
+      limit: 100,
       fields: fields,
       selector: selector,
     });
-    const unique = [...new Set(result.docs.map(x => x[fields[0]]))];
+    const docs = []
+    for (let doc of result.docs) {
+      doc = doc[fields[0]].trim()
+      doc = doc.replace("ß", "ss")
+      docs.push(doc)
+    }
+    const unique = new Set(docs);
     const arr =  []
     for (const val of unique) {
       const obj = {}
       obj[fields[0]] = val
       arr.push(obj)
-  }
+    }
     return arr;
   }
 

--- a/Frontend/src/components/TableEditors/Customers/CustomerPopupFormular.svelte
+++ b/Frontend/src/components/TableEditors/Customers/CustomerPopupFormular.svelte
@@ -23,6 +23,13 @@
     );
   }
 
+  const attributeStartsWithIgnoreCaseSelector = (field, searchValue) =>
+    $customerDb
+      .selectorBuilder()
+      .withField(field)
+      .startsWithIgnoreCase(searchValue)
+      .build();
+
   const popupFormularConfiguration = new PopupFormularConfiguration()
     .setTitle(`Kunde ${createNew ? "anlegen" : "bearbeiten"}`)
     .setDisplayDeleteButton(!createNew)
@@ -52,8 +59,21 @@
         id: "street",
         label: "Strasse",
         group: "Adresse",
-        type: InputTypes.TEXT,
+        type: InputTypes.AUTOCOMPLETE,
         bindTo: { keyValueStoreKey: "currentDoc", attr: "street" },
+        onChange: (selectedItem) => {
+          keyValueStore.setValue("currentDoc", {
+            ...$keyValueStore["currentDoc"],
+            street: selectedItem.street,
+          });
+        },
+        searchFunction: (searchTerm) =>
+          $customerDb.fetchUniqueDocsBySelector(
+            attributeStartsWithIgnoreCaseSelector("street", searchTerm),
+            ["street"]
+          ),
+        suggestionFormat: (street) => `${street}`,
+        noResultsText: "Straße noch nicht in Datenbank",
       },
       {
         id: "house_number",
@@ -66,15 +86,41 @@
         id: "postal_code",
         label: "Postleitzahl",
         group: "Adresse",
-        type: InputTypes.TEXT,
+        type: InputTypes.AUTOCOMPLETE,
         bindTo: { keyValueStoreKey: "currentDoc", attr: "postal_code" },
+        onChange: (selectedItem) => {
+          keyValueStore.setValue("currentDoc", {
+            ...$keyValueStore["currentDoc"],
+            postal_code: selectedItem.postal_code,
+          });
+        },
+        searchFunction: (searchTerm) =>
+          $customerDb.fetchUniqueDocsBySelector(
+            attributeStartsWithIgnoreCaseSelector("postal_code", searchTerm),
+            ["postal_code"]
+          ),
+        suggestionFormat: (postal_code) => `${postal_code}`,
+        noResultsText: "PLZ noch nicht in Datenbank",
       },
       {
         id: "city",
         label: "Stadt",
         group: "Adresse",
-        type: InputTypes.TEXT,
+        type: InputTypes.AUTOCOMPLETE,
         bindTo: { keyValueStoreKey: "currentDoc", attr: "city" },
+        onChange: (selectedItem) => {
+          keyValueStore.setValue("currentDoc", {
+            ...$keyValueStore["currentDoc"],
+            city: selectedItem.city,
+          });
+        },
+        searchFunction: (searchTerm) =>
+          $customerDb.fetchUniqueDocsBySelector(
+            attributeStartsWithIgnoreCaseSelector("city", searchTerm),
+            ["city"]
+          ),
+        suggestionFormat: (city) => `${city}`,
+        noResultsText: "Stadt noch nicht in Datenbank",
       },
       {
         id: "email",


### PR DESCRIPTION
![capture](https://user-images.githubusercontent.com/14980558/103534319-ef2da280-4e8e-11eb-91d9-8e24791f6678.gif)


I made a first attempt at autocompleting from the database. However as many entries are duplicates ('Karlsruhe', 'Gerwigstrasse'), I tried to implement a function to only retrieve and suggest unique items. This has the drawback that the entire DB needs to be queried on each `find()` and it therefore is relatively slow.

This was more for myself to get a bit more used to Svelte and JS, so I'd be okay if you completely reject it (but only if you let me learn from it!) ;-)

Unfortunately `pouch-db-find` has no builtin functionality to only look for uniques. There is some solution with `db.collections.distinct` - but I could not get that to work :( Is there another, faster solution to get unique fields from the db? Else we can also just leave it at 10 and live with that the table contains duplicates or maybe does not list everything.