### PR TITLE
update cache

### DIFF
--- a/Frontend/public/service-worker.js
+++ b/Frontend/public/service-worker.js
@@ -7,45 +7,41 @@ var urlsToCache = [
   "favicon.png",
 ];
 
-// https://developers.google.com/web/fundamentals/primers/service-workers
-
 self.addEventListener("install", function (event) {
-  // Perform install steps
-  event.waitUntil(
-    caches.open(CACHE_NAME).then(function (cache) {
-      return cache.addAll(urlsToCache);
-    })
-  );
+  event.waitUntil(async () => {
+    const cache = await caches.open(CACHE_NAME);
+    await cache.addAll(urlsToCache);
+  });
 });
 
-self.addEventListener("fetch", function (event) {
-  // exclude couchdb requests
-  if (event.request.url.includes("5984")) {
-    return false;
-  }
+// delete old caches
+self.addEventListener("activate", (event) => {
+  event.waitUntil(async () => {
+    const cacheNames = await caches.keys();
+    await Promise.all(
+      cacheNames
+        .filter((cacheName) => cacheName !== CACHE_NAME)
+        .forEach((cacheName) => caches.delete(cacheName))
+    );
+  });
+});
+
+self.addEventListener("fetch", (event) => {
   event.respondWith(
-    caches.match(event.request).then(function (response) {
-      // Cache hit - return response
-      if (response) {
-        return response;
-      }
-      return fetch(event.request);
-    })
-  );
-});
+    (async function () {
+      const cache = await caches.open(CACHE_NAME);
+      const cachedResponse = await cache.match(event.request);
+      const networkResponsePromise = fetch(event.request);
 
-self.addEventListener("activate", function (event) {
-  var cacheAllowlist = [CACHE_NAME];
-
-  event.waitUntil(
-    caches.keys().then(function (cacheNames) {
-      return Promise.all(
-        cacheNames.map(function (cacheName) {
-          if (cacheAllowlist.indexOf(cacheName) === -1) {
-            return caches.delete(cacheName);
-          }
-        })
+      event.waitUntil(
+        (async function () {
+          const networkResponse = await networkResponsePromise;
+          await cache.put(event.request, networkResponse.clone());
+        })()
       );
-    })
+
+      // Returned the cached response if we have one, otherwise return the network response.
+      return cachedResponse || networkResponsePromise;
+    })()
   );
 });


### PR DESCRIPTION
Instead of only serving the page from the cache, the service worker now updates the cache on each reload (when the app is opened or F5 is pressed). 

**Advantages**
- still served from cache -> opens fast and works offline
- updates automatically

**Disadvantages**
- needs two reloads to update (one to update the cache and one to load from the updated cache)

I think this is fine because it's not that important to have the newest version right away. If required, the newest version can still be loaded by pressing F5 twice.