### PR TITLE
refresh only on save

### DIFF
--- a/Frontend/src/components/TableEditors/Customers/CustomerPopupFormular.svelte
+++ b/Frontend/src/components/TableEditors/Customers/CustomerPopupFormular.svelte
@@ -10,6 +10,7 @@
   const { close } = getContext("simple-modal");
 
   export let createNew;
+  export let onSave;
 
   if (createNew) {
     keyValueStore.setValue("currentDoc", {
@@ -219,6 +220,7 @@
     savePromise
       .then((result) => notifier.success('Kunde gespeichert!'))
       .then(close)
+      .then(onSave)
       .catch((error) => {
         notifier.danger('Kunde konnte nicht gespeichert werden!', 6000);
         console.error(error);

--- a/Frontend/src/components/TableEditors/Customers/CustomerPopupFormular.svelte
+++ b/Frontend/src/components/TableEditors/Customers/CustomerPopupFormular.svelte
@@ -207,6 +207,7 @@
         .removeDoc(doc)
         .then(() => notifier.success('Kunde gelöscht!'))
         .then(close)
+        .then(onSave)
         .catch((error) => {
           console.error(error);
           notifier.danger('Kunde konnte nicht gelöscht werden!', 6000);

--- a/Frontend/src/components/TableEditors/DatabaseTableEditor.svelte
+++ b/Frontend/src/components/TableEditors/DatabaseTableEditor.svelte
@@ -14,7 +14,6 @@
   let table;
 
   const openStyledModal = getContext("openStyledModal");
-  const onModalClose = () => table.refresh();
 </script>
 
 <Table
@@ -25,13 +24,19 @@
   {rowBackgroundColorFunction}
   onRowClicked={(doc) => {
     keyValueStore.setValue('currentDoc', doc);
-    openStyledModal(popupFormularComponent, { createNew: false }, onModalClose);
+    openStyledModal(popupFormularComponent, {
+      createNew: false,
+      onSave: table.refresh,
+    });
   }} />
 
 {#if addNewItemButton}
   <AddNewItemButton
     on:click={() => {
       keyValueStore.removeValue('currentDoc');
-      openStyledModal(popupFormularComponent, { createNew: true }, onModalClose);
+      openStyledModal(popupFormularComponent, {
+        createNew: true,
+        onSave: table.refresh,
+      });
     }} />
 {/if}

--- a/Frontend/src/components/TableEditors/Items/ItemPopupFormular.svelte
+++ b/Frontend/src/components/TableEditors/Items/ItemPopupFormular.svelte
@@ -187,6 +187,7 @@
                 .removeDoc(doc)
                 .then(() => notifier.success('Gegenstand gelöscht!'))
                 .then(close)
+                .then(onSave)
                 .catch((error) => {
                     console.error(error);
                     notifier.danger('Gegenstand konnte nicht gelöscht werden!', 6000);

--- a/Frontend/src/components/TableEditors/Items/ItemPopupFormular.svelte
+++ b/Frontend/src/components/TableEditors/Items/ItemPopupFormular.svelte
@@ -12,6 +12,7 @@
     const woocommerceClient = new WoocommerceClient();
 
     export let createNew;
+    export let onSave;
 
     if (createNew) {
         keyValueStore.setValue("currentDoc", {
@@ -198,6 +199,7 @@
         await savePromise
             .then((result) => notifier.success('Gegenstand gespeichert!'))
             .then(close)
+            .then(onSave)
             .catch((error) => {
                 notifier.danger('Gegenstand konnte nicht gespeichert werden!', 6000);
                 console.error(error);

--- a/Frontend/src/components/TableEditors/Rentals/RentalPopupFormular.svelte
+++ b/Frontend/src/components/TableEditors/Rentals/RentalPopupFormular.svelte
@@ -16,6 +16,8 @@
     const woocommerceClient = new WoocommerceClient();
 
     export let createNew;
+    export let onSave;
+
     if (createNew) {
         keyValueStore.setValue("currentDoc", {
             rented_on: new Date().getTime(),
@@ -333,6 +335,7 @@
         (createNew ? $rentalDb.createDocWithoutId(doc) : $rentalDb.updateDoc(doc))
             .then((result) => notifier.success('Leihvorgang gespeichert!'))
             .then(close)
+            .then(onSave)
             .catch((error) => {
                 notifier.danger('Leihvorgang konnte nicht gespeichert werden!', 6000);
                 console.error(error);
@@ -344,6 +347,7 @@
                 .removeDoc($keyValueStore['currentDoc'])
                 .then(() => notifier.success('Leihvorgang gelöscht!'))
                 .then(close)
+                .then(onSave)
                 .catch((error) => {
                     console.error(error);
                     notifier.danger('Leihvorgang konnte nicht gelöscht werden!', 6000);


### PR DESCRIPTION
When closing a Popup, the table now only refreshes if the document was saved. When the user pressed cancel there are no changes so the table does not need to refresh.