### PR TITLE
Add count of rentals for items and customers

### DIFF
--- a/Frontend/src/components/Database/Database.js
+++ b/Frontend/src/components/Database/Database.js
@@ -109,6 +109,18 @@ class Database {
     }
   }
 
+  async countDocs(selectors) {
+    console.log(selectors)
+    const countPromise = this.findCached({
+      limit: 99999999,
+      fields: ["_id"],
+      selector: {
+        $and: selectors,
+      },
+    }).then((result) => result.docs.length);
+    return countPromise
+  }
+
   async docsMatchingAllSelectorsSortedBy(options) {
     const { selectors, sortBy, rowsPerPage, skip } = options;
 

--- a/Frontend/src/components/Database/Database.js
+++ b/Frontend/src/components/Database/Database.js
@@ -110,7 +110,6 @@ class Database {
   }
 
   async countDocs(selectors) {
-    console.log(selectors)
     const countPromise = this.findCached({
       limit: 99999999,
       fields: ["_id"],

--- a/Frontend/src/components/TableEditors/Customers/CustomerPopupFormular.svelte
+++ b/Frontend/src/components/TableEditors/Customers/CustomerPopupFormular.svelte
@@ -38,6 +38,16 @@
         id: id,
       })
     );
+  } else {
+    async function countRentals() {
+      const selectors = [
+        {
+          customer_id: $keyValueStore["currentDoc"]["id"],
+        },
+      ];
+      return await Database.countDocs(selectors);
+    }
+    countRentals().then((data) => ($keyValueStore["currentDoc"]["number_of_rentals"] = data));
   }
 
   const popupFormularConfiguration = new PopupFormularConfiguration()
@@ -183,6 +193,18 @@
         group: "Sonstiges",
         type: InputTypes.TEXT,
         bindTo: { keyValueStoreKey: "currentDoc", attr: "remark" },
+      },
+      {
+        id: "number_of_rentals",
+        disabled: createNew,
+        label: "Gegenstände geliehen",
+        group: "Sonstiges",
+        type: InputTypes.TEXT,
+        readonly: true,
+        bindTo: {
+          keyValueStoreKey: "currentDoc",
+          attr: "number_of_rentals",
+        },
       },
       {
         id: "highlight",

--- a/Frontend/src/components/TableEditors/Items/ItemPopupFormular.svelte
+++ b/Frontend/src/components/TableEditors/Items/ItemPopupFormular.svelte
@@ -45,6 +45,16 @@
         id: id,
       })
     );
+  } else {
+    async function countRentals() {
+      const selectors = [
+        {
+          item_id: $keyValueStore["currentDoc"]["id"],
+        },
+      ];
+      return await Database.countDocs(selectors);
+    }
+    countRentals().then((data) => ($keyValueStore["currentDoc"]["number_of_rentals"] = data));
   }
 
   const docIsDeleted = $keyValueStore["currentDoc"].status === "deleted";
@@ -120,6 +130,18 @@
         group: "Eigenschaften",
         type: InputTypes.DATE,
         bindTo: { keyValueStoreKey: "currentDoc", attr: "added" },
+      },
+      {
+        id: "number_of_rentals",
+        disabled: createNew,
+        label: "Anzahl Ausleihen",
+        group: "Eigenschaften",
+        type: InputTypes.TEXT,
+        readonly: true,
+        bindTo: {
+          keyValueStoreKey: "currentDoc",
+          attr: "number_of_rentals",
+        },
       },
       {
         id: "description",


### PR DESCRIPTION
I've added a functionality that counts how often an item has been rented, or how many rentals a customer has. it's loading lazily, so not slowing down the UI :)

It's added to the `keyValueStore["currentDoc"]["number_of_rentals"]` - that probably means that it's also written to the db. However, as there is no change no new shard will be created, right, and anyway only if save is clicked? Else let me know how I can display it without it being automatically saved to the doc, could not find out how to without creating a new Input field like `InputLabel` or so, so without bindings. Should I do it with a new `Input` Element that just displays things without binding?

For items
![image](https://user-images.githubusercontent.com/14980558/111844901-28a97200-8904-11eb-8312-03c965b310f2.png)

For customers
![image](https://user-images.githubusercontent.com/14980558/111845005-58587a00-8904-11eb-9fb4-aed2f40c3d2a.png)
