### PR TITLE
Temporarily remember previous employees initials

### DIFF
--- a/Frontend/src/components/Input/ButtonTight.svelte
+++ b/Frontend/src/components/Input/ButtonTight.svelte
@@ -1,9 +1,8 @@
 <script>
   export let text;
-  export let onclick;
 </script>
 
-<button class="button-tight" on:click={onclick}>{text}</button>
+<button class="button-tight" on:click>{text}</button>
 
 <style>
   .button-tight {

--- a/Frontend/src/components/Input/ButtonTight.svelte
+++ b/Frontend/src/components/Input/ButtonTight.svelte
@@ -1,0 +1,20 @@
+<script>
+  export let text;
+  export let onclick;
+</script>
+
+<button class="button-tight" on:click={onclick}>{text}</button>
+
+<style>
+  .button-tight {
+    height: 1.5rem;
+    font-size: smaller;
+    line-height: 0.75rem;
+    margin-top: 0.25rem;
+    margin-left: 0.1rem;
+  }
+  .button-tight:hover {
+    transition: 0.25s all;
+    transform: scale(1.02);
+  }
+</style>

--- a/Frontend/src/components/Input/DateInput.svelte
+++ b/Frontend/src/components/Input/DateInput.svelte
@@ -6,6 +6,7 @@
     millisAtStartOfDay,
   } from "../../utils/utils";
   import { createEventDispatcher } from "svelte";
+  import ButtonTight from "./ButtonTight.svelte";
 
   const dispatch = createEventDispatcher();
 
@@ -66,10 +67,8 @@
   </DatePicker>
 {/if}
 
-{#each Object.entries(quickset) as [days, label]}
-  <button class="button-tight" on:click={() => addDays(parseInt(days))}
-    >{label}</button
-  >
+{#each Object.entries(quickset) as [days, text]}
+  <ButtonTight {text} onclick={() => addDays(parseInt(days))} />
 {/each}
 
 <style>
@@ -87,12 +86,5 @@
   input[disabled] {
     color: #dcdad1;
     background-color: rgba(239, 239, 239, 0.3);
-  }
-  .button-tight {
-    height: 1.5rem;
-    font-size: smaller;
-    line-height: 0.75rem;
-    margin-top: 0.25rem;
-    margin-left: 0.1rem;
   }
 </style>

--- a/Frontend/src/components/Input/DateInput.svelte
+++ b/Frontend/src/components/Input/DateInput.svelte
@@ -68,7 +68,7 @@
 {/if}
 
 {#each Object.entries(quickset) as [days, text]}
-  <ButtonTight {text} onclick={() => addDays(parseInt(days))} />
+  <ButtonTight {text} on:click={() => addDays(parseInt(days))} />
 {/each}
 
 <style>

--- a/Frontend/src/components/Input/TextInput.svelte
+++ b/Frontend/src/components/Input/TextInput.svelte
@@ -60,7 +60,7 @@
 {#each Object.entries(quickset) as [target, text]}
   <ButtonTight
     {text}
-    onclick={() => {
+    on:click={() => {
       value = target;
     }}
   />

--- a/Frontend/src/components/Input/TextInput.svelte
+++ b/Frontend/src/components/Input/TextInput.svelte
@@ -8,6 +8,7 @@
   export let disabled = false;
   export let multiline = false;
   export let onlyNumbers = false;
+  export let quickset = {};
 
   let textAreaRef;
   const dispatch = createEventDispatcher();
@@ -20,7 +21,6 @@
   };
 
   onMount(resizeTextArea);
-
   $: if (onlyNumbers && typeof value !== "number" && value !== "") {
     value = parseInt(value);
   }
@@ -50,12 +50,20 @@
       name={id}
       {readonly}
       {disabled}
-      on:keydown={(event) =>
-        event.key === "Enter" ? event.preventDefault() : event}
+      on:keydown={(event) => (event.key === "Enter" ? event.preventDefault() : event)}
       on:input={(event) => dispatch("change", event.target.value)}
     />
   {/if}
 </form>
+
+{#each Object.entries(quickset) as [val, label]}
+  <button
+    class="button-tight"
+    on:click={() => {
+      value = val;
+    }}>{label}</button
+  >
+{/each}
 
 <style>
   input[type="text"] {
@@ -71,5 +79,12 @@
     width: 100% !important;
     resize: none;
     overflow: hidden;
+  }
+  .button-tight {
+    height: 1.5rem;
+    font-size: smaller;
+    line-height: 0.75rem;
+    margin-top: 0.25rem;
+    margin-left: 0.1rem;
   }
 </style>

--- a/Frontend/src/components/Input/TextInput.svelte
+++ b/Frontend/src/components/Input/TextInput.svelte
@@ -1,6 +1,7 @@
 <script>
   import { createEventDispatcher, onMount } from "svelte";
   import { restrictInputToNumbers } from "../../actions/RestrictInputToNumbers";
+  import ButtonTight from "./ButtonTight.svelte";
 
   export let id = "";
   export let readonly = false;
@@ -43,7 +44,6 @@
     />
   {:else}
     <input
-      use:restrictInputToNumbers={onlyNumbers}
       type="text"
       bind:value
       {id}
@@ -57,13 +57,13 @@
   {/if}
 </form>
 
-{#each Object.entries(quickset) as [val, label]}
-  <button
-    class="button-tight"
-    on:click={() => {
-      value = val;
-    }}>{label}</button
-  >
+{#each Object.entries(quickset) as [target, text]}
+  <ButtonTight
+    {text}
+    onclick={() => {
+      value = target;
+    }}
+  />
 {/each}
 
 <style>
@@ -80,12 +80,5 @@
     width: 100% !important;
     resize: none;
     overflow: hidden;
-  }
-  .button-tight {
-    height: 1.5rem;
-    font-size: smaller;
-    line-height: 0.75rem;
-    margin-top: 0.25rem;
-    margin-left: 0.1rem;
   }
 </style>

--- a/Frontend/src/components/Input/TextInput.svelte
+++ b/Frontend/src/components/Input/TextInput.svelte
@@ -50,7 +50,8 @@
       name={id}
       {readonly}
       {disabled}
-      on:keydown={(event) => (event.key === "Enter" ? event.preventDefault() : event)}
+      on:keydown={(event) =>
+        event.key === "Enter" ? event.preventDefault() : event}
       on:input={(event) => dispatch("change", event.target.value)}
     />
   {/if}

--- a/Frontend/src/data/rental/inputs.js
+++ b/Frontend/src/data/rental/inputs.js
@@ -5,8 +5,10 @@ import Checkbox from "../../components/Input/Checkbox.svelte";
 import Database from "../../database/ENV_DATABASE";
 import onSave from "./onSave";
 import onDelete from "./onDelete";
+import {recentEmployeesStore} from "../../utils/stores";
 import initialValues from "./initialValues";
 import { notifier } from "@beyonk/svelte-notifications";
+import { get } from 'svelte/store';
 import {
   customerIdStartsWithSelector,
   itemIdStartsWithAndNotDeletedSelector,
@@ -18,6 +20,7 @@ import {
   customerByLastname,
   itemByName,
 } from "../selectors";
+
 
 /**
  * Whether the status of the selected item should be updated when a rental is created or completed.
@@ -38,6 +41,15 @@ const updateToggleStatus = (itemExistsMoreThanOnce) => {
     hideToggleUpdateItemStatus = false;
   }
 };
+
+function getRecentEmployees(){
+  var employeeList = {};
+  for(let employee of get(recentEmployeesStore)){
+    employeeList[employee] = employee;
+  }
+  return employeeList
+};
+
 
 const updateItemOfRental = (context, item) => {
   context.updateDoc({
@@ -293,6 +305,7 @@ export default {
       hidden: (context) => context.createNew,
       component: TextInput,
       props: {
+        quickset:{0:'0'},
         onlyNumbers: true,
       },
     },
@@ -302,6 +315,9 @@ export default {
       label: "Ausgabe",
       group: "Mitarbeiter",
       component: TextInput,
+      props: {
+        quickset:getRecentEmployees,
+      },
     },
     {
       id: "receiving_employee",
@@ -309,6 +325,9 @@ export default {
       group: "Mitarbeiter",
       hidden: (context) => context.createNew,
       component: TextInput,
+      props: {
+        quickset:getRecentEmployees,
+      },
     },
     {
       id: "remark",

--- a/Frontend/src/data/rental/inputs.js
+++ b/Frontend/src/data/rental/inputs.js
@@ -305,7 +305,7 @@ export default {
       hidden: (context) => context.createNew,
       component: TextInput,
       props: {
-        quickset:{0:'0'},
+        quickset: (context) => ({ [context.doc.deposit]: context.doc.deposit }),
         onlyNumbers: true,
       },
     },

--- a/Frontend/src/data/rental/inputs.js
+++ b/Frontend/src/data/rental/inputs.js
@@ -5,10 +5,10 @@ import Checkbox from "../../components/Input/Checkbox.svelte";
 import Database from "../../database/ENV_DATABASE";
 import onSave from "./onSave";
 import onDelete from "./onDelete";
-import {recentEmployeesStore} from "../../utils/stores";
+import { recentEmployeesStore } from "../../utils/stores";
 import initialValues from "./initialValues";
 import { notifier } from "@beyonk/svelte-notifications";
-import { get } from 'svelte/store';
+import { get } from "svelte/store";
 import {
   customerIdStartsWithSelector,
   itemIdStartsWithAndNotDeletedSelector,
@@ -20,7 +20,6 @@ import {
   customerByLastname,
   itemByName,
 } from "../selectors";
-
 
 /**
  * Whether the status of the selected item should be updated when a rental is created or completed.
@@ -42,14 +41,13 @@ const updateToggleStatus = (itemExistsMoreThanOnce) => {
   }
 };
 
-function getRecentEmployees(){
+function getRecentEmployees() {
   var employeeList = {};
-  for(let employee of get(recentEmployeesStore)){
+  for (let employee of get(recentEmployeesStore)) {
     employeeList[employee] = employee;
   }
-  return employeeList
-};
-
+  return employeeList;
+}
 
 const updateItemOfRental = (context, item) => {
   context.updateDoc({
@@ -316,7 +314,7 @@ export default {
       group: "Mitarbeiter",
       component: TextInput,
       props: {
-        quickset:getRecentEmployees,
+        quickset: getRecentEmployees,
       },
     },
     {
@@ -326,7 +324,7 @@ export default {
       hidden: (context) => context.createNew,
       component: TextInput,
       props: {
-        quickset:getRecentEmployees,
+        quickset: getRecentEmployees,
       },
     },
     {

--- a/Frontend/src/data/rental/onSave.js
+++ b/Frontend/src/data/rental/onSave.js
@@ -1,5 +1,5 @@
 import Database from "../../database/ENV_DATABASE";
-import {recentEmployeesStore} from "../../utils/stores"
+import { recentEmployeesStore } from "../../utils/stores";
 import { notifier } from "@beyonk/svelte-notifications";
 import WoocommerceClient from "../../database/ENV_WC_CLIENT";
 import columns from "./columns";
@@ -77,11 +77,11 @@ export default async (rental, closePopup, updateItemStatus, createNew) => {
       `Did not update item of rental ${rental._id} because updateItemStatus is false.`
     );
   }
- 
+
   await (createNew ? Database.createDoc(rental) : Database.updateDoc(rental))
     .then((result) => notifier.success("Leihvorgang gespeichert!"))
-    .then(()=>recentEmployeesStore.add(rental.passing_out_employee))
-    .then(()=>recentEmployeesStore.add(rental.receiving_employee))
+    .then(() => recentEmployeesStore.add(rental.passing_out_employee))
+    .then(() => recentEmployeesStore.add(rental.receiving_employee))
     .then(closePopup)
     .catch((error) => {
       notifier.danger("Leihvorgang konnte nicht gespeichert werden!", {

--- a/Frontend/src/data/rental/onSave.js
+++ b/Frontend/src/data/rental/onSave.js
@@ -1,4 +1,5 @@
 import Database from "../../database/ENV_DATABASE";
+import {recentEmployeesStore} from "../../utils/stores"
 import { notifier } from "@beyonk/svelte-notifications";
 import WoocommerceClient from "../../database/ENV_WC_CLIENT";
 import columns from "./columns";
@@ -76,9 +77,11 @@ export default async (rental, closePopup, updateItemStatus, createNew) => {
       `Did not update item of rental ${rental._id} because updateItemStatus is false.`
     );
   }
-
+ 
   await (createNew ? Database.createDoc(rental) : Database.updateDoc(rental))
     .then((result) => notifier.success("Leihvorgang gespeichert!"))
+    .then(()=>recentEmployeesStore.add(rental.passing_out_employee))
+    .then(()=>recentEmployeesStore.add(rental.receiving_employee))
     .then(closePopup)
     .catch((error) => {
       notifier.danger("Leihvorgang konnte nicht gespeichert werden!", {

--- a/Frontend/src/utils/stores.js
+++ b/Frontend/src/utils/stores.js
@@ -25,8 +25,10 @@ const createRecentEmployeesSet = () => {
   return {
     ...store,
     add: (string) =>
-      store.update((prevStore) => string ? (new Set([...prevStore, string])):prevStore),
-    size: () => store.size
+      store.update((prevStore) =>
+        string ? new Set([...prevStore, string]) : prevStore
+      ),
+    size: () => store.size,
   };
 };
 

--- a/Frontend/src/utils/stores.js
+++ b/Frontend/src/utils/stores.js
@@ -18,4 +18,17 @@ const createKeyValueStore = () => {
   };
 };
 
+const createRecentEmployeesSet = () => {
+  // a set, that means each value is only included once
+  const store = writable(new Set([]));
+
+  return {
+    ...store,
+    add: (string) =>
+      store.update((prevStore) => string ? (new Set([...prevStore, string])):prevStore),
+    size: () => store.size
+  };
+};
+
 export const keyValueStore = createKeyValueStore();
+export const recentEmployeesStore = createRecentEmployeesSet();


### PR DESCRIPTION
I've implemented #228 

It now saves all employee initials of the current session into a store: `writable(Set())`.
![asdf](https://user-images.githubusercontent.com/14980558/154701460-be74aea8-98ea-4a73-bf79-cceda6423853.gif)

Not sure if this was the optimal way to do it, I simply used what I know from previous PRs.

I'd like to implement the same button for "Pfand zurück" @daniel17903: how do I reference elements of the current popup form from the `input.js`? Is that even possible?


closes #228 