### PR TITLE
only mark current late rentals as red

### DIFF
--- a/Frontend/src/data/rental/columns.js
+++ b/Frontend/src/data/rental/columns.js
@@ -13,17 +13,16 @@ const shouldBeReturnedToday = (rental) =>
   rental.to_return_on &&
   rental.to_return_on === millisAtStartOfToday() &&
   !hasReturnDate(rental);
-const shouldHaveBeenReturnedBeforeToday = (rental) =>
+const shouldHaveBeenReturnedBeforeTodayAndIsNotReturned = (rental) =>
   rental.to_return_on &&
-  ((!hasReturnDate(rental) && rental.to_return_on < millisAtStartOfToday()) ||
-    (hasReturnDate(rental) && rental.to_return_on < rental.returned_on));
+  (!hasReturnDate(rental) && rental.to_return_on < millisAtStartOfToday());
 
 const rentalHighlight = async (rental) => {
   if (hasBeenReturnedToday(rental)) {
     return COLORS.RENTAL_RETURNED_TODAY_GREEN;
   } else if (shouldBeReturnedToday(rental)) {
     return COLORS.RENTAL_TO_RETURN_TODAY_BLUE;
-  } else if (shouldHaveBeenReturnedBeforeToday(rental)) {
+  } else if (shouldHaveBeenReturnedBeforeTodayAndIsNotReturned(rental)) {
     return COLORS.RENTAL_LATE_RED;
   }
 };


### PR DESCRIPTION
Until now, rentals that were returned late but are already a few days ago still were marked in red. I found that this sometimes confused some people as they thought "something was wrong" with these, even though the item has been returned fine (albeit too late).

I propose to change the colouring to only mark rentals red if they should be returned by now, but are not yet.

What do you think?