### PR TITLE
add option to duplicate a form

### DIFF
--- a/Frontend/src/components/TableView/PopupFormular/Formular.svelte
+++ b/Frontend/src/components/TableView/PopupFormular/Formular.svelte
@@ -8,6 +8,7 @@
   export let createNew = false;
   export let closePopup;
   export let copyPopup;
+  export let duplicated = false;
 
   let groupedInputs = [];
   let title = "";
@@ -23,6 +24,7 @@
       return val({
         doc,
         createNew,
+        duplicated,
         closePopup,
         copyPopup,
         updateDoc: (updatedDoc) => (doc = { ...doc, ...updatedDoc }),
@@ -56,10 +58,14 @@
         (groupedInputs[group] = inputs.filter((input) => input.group === group))
     );
 
-    if (createNew) {
+    if (createNew & !duplicated) {
       // load initial values (e.g. first unused id when creating a new customer)
       Object.keys(config.initialValues).forEach(async (key) => {
         doc[key] = await config.initialValues[key]();
+      });
+    } else if (duplicated) {
+      Object.keys(config.duplicatedValues).forEach(async (key) => {
+        doc[key] = await config.duplicatedValues[key]();
       });
     }
   });

--- a/Frontend/src/components/TableView/PopupFormular/Formular.svelte
+++ b/Frontend/src/components/TableView/PopupFormular/Formular.svelte
@@ -7,6 +7,7 @@
   export let doc = {};
   export let createNew = false;
   export let closePopup;
+  export let copyPopup;
 
   let groupedInputs = [];
   let title = "";
@@ -23,6 +24,7 @@
         doc,
         createNew,
         closePopup,
+        copyPopup,
         updateDoc: (updatedDoc) => (doc = { ...doc, ...updatedDoc }),
         container: inputContainer,
       });

--- a/Frontend/src/components/TableView/PopupFormular/PopupFormular.svelte
+++ b/Frontend/src/components/TableView/PopupFormular/PopupFormular.svelte
@@ -6,8 +6,16 @@
   const modal = writable();
   let onClose;
 
+  function duplicate(props, fill_values) {
+    modal.set(null);
+    props["createNew"] = true;
+    props["config"]["initialValues"] = fill_values;
+    show(props);
+  }
+
   export function show(props, onCloseCallback = () => {}) {
     props["closePopup"] = () => modal.set(null);
+    props["copyPopup"] = (fill_values) => duplicate(props, fill_values);
     onClose = onCloseCallback;
     modal.set(bind(Formular, props));
   }

--- a/Frontend/src/components/TableView/PopupFormular/PopupFormular.svelte
+++ b/Frontend/src/components/TableView/PopupFormular/PopupFormular.svelte
@@ -9,13 +9,15 @@
   function duplicate(props, fill_values) {
     modal.set(null);
     props["createNew"] = true;
-    props["config"]["initialValues"] = fill_values;
-    show(props);
+    props["duplicated"] = true;
+    props["config"]["duplicatedValues"] = fill_values;
+    show(props); // show again with duplicated values
   }
 
   export function show(props, onCloseCallback = () => {}) {
     props["closePopup"] = () => modal.set(null);
-    props["copyPopup"] = (fill_values) => duplicate(props, fill_values);
+    props["copyPopup"] = (fill_values) =>
+      duplicate(props, fill_values) && modal.set(null);
     onClose = onCloseCallback;
     modal.set(bind(Formular, props));
   }

--- a/Frontend/src/data/rental/inputs.js
+++ b/Frontend/src/data/rental/inputs.js
@@ -152,7 +152,8 @@ export default {
           context.doc,
           context.copyPopup,
           updateItemStatus,
-          context.createNew
+          context.createNew,
+          true // duplicate=true
         ),
       hidden: !context.createNew,
       loadingText: "Leihvorgang wird gespeichert",

--- a/Frontend/src/data/rental/inputs.js
+++ b/Frontend/src/data/rental/inputs.js
@@ -124,6 +124,18 @@ export default {
       loadingText: "Leihvorgang wird gelöscht",
     },
     {
+      text: "Speichern & Duplizieren",
+      onClick: () =>
+        onSave(
+          context.doc,
+          context.copyPopup,
+          updateItemStatus,
+          context.createNew
+        ),
+      hidden: !context.createNew,
+      loadingText: "Leihvorgang wird gespeichert",
+    },
+    {
       text: "Speichern",
       onClick: () =>
         onSave(

--- a/Frontend/src/data/rental/onSave.js
+++ b/Frontend/src/data/rental/onSave.js
@@ -83,6 +83,19 @@ export default async (
           );
           Logger.error(error);
         });
+      console.log(duplicateForm);
+
+      // show a persistent info notifier of previous items when duplicating a form
+      // this makes it easier to keep in mind what previous items you just rented for
+      // the same person
+      if (duplicateForm) {
+        notifier.info(
+          `Gespeichert: '${rental.item_name}', Pfand: ${rental.deposit}€ bis ${rental.to_return_on}`,
+          {
+            persist: true,
+          }
+        );
+      }
     } else {
       Logger.warn(
         `Did not update item of rental ${rental._id} because item not found.`

--- a/Frontend/src/data/rental/onSave.js
+++ b/Frontend/src/data/rental/onSave.js
@@ -78,11 +78,21 @@ export default async (rental, closePopup, updateItemStatus, createNew) => {
     );
   }
 
+  const duplicateRental = (rental) => {
+    var rental_copy = new Object();
+    Object.keys(rental).forEach(function (key) {
+      if (["deposit", "item_name", "item_id"].indexOf(key) == -1) {
+        rental_copy[key] = () => rental[key];
+      }
+    });
+    return rental_copy;
+  };
+
   await (createNew ? Database.createDoc(rental) : Database.updateDoc(rental))
     .then((result) => notifier.success("Leihvorgang gespeichert!"))
     .then(() => recentEmployeesStore.add(rental.passing_out_employee))
     .then(() => recentEmployeesStore.add(rental.receiving_employee))
-    .then(closePopup)
+    .then(() => closePopup(duplicateRental(rental)))
     .catch((error) => {
       notifier.danger("Leihvorgang konnte nicht gespeichert werden!", {
         persist: true,


### PR DESCRIPTION
Heyho, I implemented #255 as we discussed :)

There is now a second button that is named "Speichern & Duplizieren"
- the form is copied, except for some properties
- I tried to keep it modular, so what gets copied is written in "inputs.js"
- we should definitely write some tests for this, I think there can be some problems with the form not properly restoring/cleaning and leaking over to new popups (happened at previous iterations of the code sometimes). But I don't know how to do that. :(

this was fun to implement! hope it is not too hacky, let me know what can be done differently.

![newasd](https://user-images.githubusercontent.com/14980558/166656023-c9aaee3c-6f42-4ed0-a11c-30a34d5b259e.gif)

