### PR TITLE
Show notification if item is not available (e.g. reserved)

### DIFF
--- a/Frontend/src/data/rental/inputs.js
+++ b/Frontend/src/data/rental/inputs.js
@@ -55,6 +55,7 @@ const updateItemOfRental = (context, item) => {
     item_name: item.name,
     deposit: item.deposit,
   });
+  showNotificationsIfNotAvailable(item);
   updateToggleStatus(item.exists_more_than_once);
 };
 
@@ -64,6 +65,22 @@ const updateCustomerOfRental = (context, customer) => {
     customer_id: customer.id,
   });
   showNotificationsForCustomer(customer.id);
+};
+
+const showNotificationsIfNotAvailable = (item) => {
+  var status_mapping = {
+    instock: "verfügbar",
+    outofstock: "verliehen",
+    reserved: "reserviert",
+    onbackorder: "temporär nicht verfügbar / in Reparatur",
+  };
+  var status = status_mapping[item.status];
+  if (item.status != "instock") {
+    notifier.danger(
+      `Gegenstand ist nicht verfügbar, hat Status: ${status}`,
+      6000
+    );
+  }
 };
 
 const showNotificationsForCustomer = async (customerId) => {
@@ -148,7 +165,7 @@ export default {
         searchFunction: (context) => (searchTerm) =>
           Database.fetchDocsBySelector(
             itemIdStartsWithAndNotDeletedSelector(searchTerm),
-            ["id", "name", "deposit", "exists_more_than_once"]
+            ["id", "name", "deposit", "exists_more_than_once", "status"]
           ),
         suggestionFormat: (context) => (id, item_name) =>
           `${String(id).padStart(4, "0")}: ${item_name}`,


### PR DESCRIPTION
It happens sometimes that items are reserved and some people overlook the reservation and accidentially lend the item to someone, even if somebody else has reserved the item. This should fix it by displaying a notification when the item status is not "instock" // "verfügbar"

![Animation](https://user-images.githubusercontent.com/14980558/169343951-e16b3db7-4cd0-485c-b885-d5cc8f1c1755.gif)
