### PR TITLE
#450 reset status of initial item to available

### DIFF
--- a/Frontend/src/components/TableView/PopupFormular/Formular.svelte
+++ b/Frontend/src/components/TableView/PopupFormular/Formular.svelte
@@ -13,6 +13,7 @@
   let groups = [];
   let inputContainer;
   let footerButtonsWithContext;
+  let contextVars = {};
 
   // needs to be reactive so that the injected context is updated when doc changes
   $: doc, (footerButtonsWithContext = injectContext(config.footerButtons));
@@ -25,6 +26,7 @@
         closePopup,
         updateDoc: (updatedDoc) => (doc = { ...doc, ...updatedDoc }),
         container: inputContainer,
+        contextVars,
       });
     } else {
       return val;

--- a/Frontend/src/data/rental/inputs.js
+++ b/Frontend/src/data/rental/inputs.js
@@ -133,6 +133,7 @@ export default {
      * check if the item was changed when saving the rental.
      */
     context.contextVars.initialItemId = context.doc.item_id;
+    context.contextVars.initialItemName = context.doc.item_name;
   },
   footerButtons: (context) => [
     {

--- a/Frontend/src/data/rental/onSave.js
+++ b/Frontend/src/data/rental/onSave.js
@@ -30,7 +30,8 @@ const newItemStatus = (rental) => {
 };
 
 const updateItemStatus = async (item, status) => {
-  await Database.updateDoc({ ...item, status });
+  item.status = status;
+  await Database.updateDoc(item);
   await WoocommerceClient.updateItem(item);
   notifier.success(
     `'${item.name}' wurde als ${
@@ -41,10 +42,14 @@ const updateItemStatus = async (item, status) => {
 
 export default async (context) => {
   const { doc, closePopup, createNew, contextVars } = context;
+  console.log(contextVars);
   setNumericValuesDefault0(doc, columns);
 
   // item changed, reset initial item to status available
-  if (contextVars.initialItemId && contextVars.initialItemId !== doc.item_id) {
+  if (
+    contextVars.initialItemId !== undefined &&
+    contextVars.initialItemId !== doc.item_id
+  ) {
     try {
       const initialItem = await fetchItemById(contextVars.initialItemId);
       await updateItemStatus(initialItem, "instock");
@@ -70,7 +75,7 @@ export default async (context) => {
       await updateItemStatus(item, newItemStatus(doc));
     } catch (error) {
       Logger.error(
-        `Failed to update status of item with id ${doc._id}, ${error}`
+        `Failed to update status of item with id ${doc.item_id}, ${error}`
       );
 
       notifier.danger(

--- a/Frontend/src/data/rental/onSave.js
+++ b/Frontend/src/data/rental/onSave.js
@@ -42,7 +42,6 @@ const updateItemStatus = async (item, status) => {
 
 export default async (context) => {
   const { doc, closePopup, createNew, contextVars } = context;
-  console.log(contextVars);
   setNumericValuesDefault0(doc, columns);
 
   // item changed, reset initial item to status available
@@ -54,15 +53,15 @@ export default async (context) => {
       const initialItem = await fetchItemById(contextVars.initialItemId);
       await updateItemStatus(initialItem, "instock");
       notifier.warning(
-        `Status des Gegenstandes mit ID '${contextVars.initialItemId}' wurde auf 'verfügbar' geändert. Bitter überprüfe ob das stimmt.`,
+        `Status von '${contextVars.initialItemName}' wurde auf 'verfügbar' geändert. Bitter überprüfe ob das stimmt.`,
         { persist: true }
       );
     } catch (error) {
       Logger.error(
-        `Failed to update status of initial item with id ${contextVars.initialItemId}, ${error}`
+        `Failed to update status of initial item with name ${contextVars.initialItemName} id ${contextVars.initialItemId}, ${error}`
       );
       notifier.warning(
-        `Status des Gegenstandes mit ID '${contextVars.initialItemId}' konnte nicht aktualisiert werden. Bitte überprüfe den Status dieses Gegenstandes.`,
+        `Status von '${contextVars.initialItemName}' konnte nicht aktualisiert werden. Bitte überprüfe den Status dieses Gegenstandes.`,
         { persist: true }
       );
     }

--- a/Frontend/src/data/rental/onSave.js
+++ b/Frontend/src/data/rental/onSave.js
@@ -7,27 +7,12 @@ import { setNumericValuesDefault0 } from "../utils";
 import { itemById } from "../selectors";
 import Logger from "js-logger";
 
-const fetchItem = async (rental) => {
-  if (rental.item_id) {
-    try {
-      const item = (
-        await Database.fetchDocsBySelector(itemById(rental.item_id))
-      )[0];
-      rental.image = item.image;
-      return item;
-    } catch (error) {
-      notifier.warning(
-        `Gegenstand '${rental.item_id}' konnte nicht geladen werden!`,
-        6000
-      );
-      Logger.error(error);
-      return undefined;
-    }
-  } else {
-    Logger.warn(
-      `Could not update item because rental ${rental._id} does not have an item_id.`
-    );
-    return undefined;
+const fetchItemById = async (itemId) => {
+  try {
+    return (await Database.fetchDocsBySelector(itemById(itemId)))[0];
+  } catch (error) {
+    Logger.error(error);
+    throw `Failed to load item with id ${itemId}`;
   }
 };
 
@@ -44,44 +29,65 @@ const newItemStatus = (rental) => {
   }
 };
 
-export default async (rental, closePopup, updateItemStatus, createNew) => {
-  setNumericValuesDefault0(rental, columns);
+const updateItemStatus = async (item, status) => {
+  await Database.updateDoc({ ...item, status });
+  await WoocommerceClient.updateItem(item);
+  notifier.success(
+    `'${item.name}' wurde als ${
+      item.status === "instock" ? "verfügbar" : "verliehen"
+    } markiert.`
+  );
+};
 
-  if (updateItemStatus) {
-    const item = await fetchItem(rental);
-    if (item) {
-      item.status = newItemStatus(rental);
-      await Database.updateDoc(item)
-        .then(() => WoocommerceClient.updateItem(item))
-        .then(() => {
-          notifier.success(
-            `'${item.name}' wurde als ${
-              item.status === "instock" ? "verfügbar" : "verliehen"
-            } markiert.`
-          );
-        })
-        .catch((error) => {
-          notifier.danger(
-            `Status von '${item.name}' konnte nicht aktualisiert werden!`,
-            { persist: true }
-          );
-          Logger.error(error);
-        });
-    } else {
-      Logger.warn(
-        `Did not update item of rental ${rental._id} because item not found.`
+export default async (context) => {
+  const { doc, closePopup, createNew, contextVars } = context;
+  setNumericValuesDefault0(doc, columns);
+
+  // item changed, reset initial item to status available
+  if (contextVars.initialItemId && contextVars.initialItemId !== doc.item_id) {
+    try {
+      const initialItem = await fetchItemById(contextVars.initialItemId);
+      await updateItemStatus(initialItem, "instock");
+      notifier.warning(
+        `Status des Gegenstandes mit ID '${contextVars.initialItemId}' wurde auf 'verfügbar' geändert. Bitter überprüfe ob das stimmt.`,
+        { persist: true }
+      );
+    } catch (error) {
+      Logger.error(
+        `Failed to update status of initial item with id ${contextVars.initialItemId}, ${error}`
+      );
+      notifier.warning(
+        `Status des Gegenstandes mit ID '${contextVars.initialItemId}' konnte nicht aktualisiert werden. Bitte überprüfe den Status dieses Gegenstandes.`,
+        { persist: true }
+      );
+    }
+  }
+
+  if (contextVars.updateItemStatus) {
+    try {
+      const item = await fetchItemById(doc.item_id);
+      doc.image = item.image;
+      await updateItemStatus(item, newItemStatus(doc));
+    } catch (error) {
+      Logger.error(
+        `Failed to update status of item with id ${doc._id}, ${error}`
+      );
+
+      notifier.danger(
+        `Status des Gegenstandes mit ID '${doc.item_id}' konnte nicht aktualisiert werden!`,
+        { persist: true }
       );
     }
   } else {
     Logger.debug(
-      `Did not update item of rental ${rental._id} because updateItemStatus is false.`
+      `Did not update item of rental ${doc._id} because updateItemStatus is false.`
     );
   }
 
-  await (createNew ? Database.createDoc(rental) : Database.updateDoc(rental))
-    .then((result) => notifier.success("Leihvorgang gespeichert!"))
-    .then(() => recentEmployeesStore.add(rental.passing_out_employee))
-    .then(() => recentEmployeesStore.add(rental.receiving_employee))
+  await (createNew ? Database.createDoc(doc) : Database.updateDoc(doc))
+    .then((_) => notifier.success("Leihvorgang gespeichert!"))
+    .then(() => recentEmployeesStore.add(doc.passing_out_employee))
+    .then(() => recentEmployeesStore.add(doc.receiving_employee))
     .then(closePopup)
     .catch((error) => {
       notifier.danger("Leihvorgang konnte nicht gespeichert werden!", {


### PR DESCRIPTION
If the item in an existing rental is changed, the status of the initial item is reset to "available" automatically. Also a notification is shown that the user should check if this status is correct.