### PR TITLE
Change recent employee store to OrderedSet

### DIFF
--- a/Frontend/src/data/rental/inputs.js
+++ b/Frontend/src/data/rental/inputs.js
@@ -52,6 +52,7 @@ function suggestReceivingEmployee(context) {
   }
 
   let mostRecent;
+  // retrieve last element of array
   for (mostRecent of get(recentEmployeesStore));
 
   if (!mostRecent) {

--- a/Frontend/src/utils/stores.js
+++ b/Frontend/src/utils/stores.js
@@ -18,19 +18,23 @@ const createKeyValueStore = () => {
   };
 };
 
-const createRecentEmployeesSet = () => {
-  // a set, that means each value is only included once
-  const store = writable(new Set([]));
+const createRecentEmployeesOrderedSet = () => {
+  // a array, that means each value is only included once
+  // however, we overwrite the "add" function to only add
+  // items that are not in the list yet. So it is basically
+  // a Set that is ordered by insertion order
+  const store = writable(new Array());
 
   return {
     ...store,
     add: (string) =>
       store.update((prevStore) =>
-        string ? new Set([...prevStore, string]) : prevStore
+        string && !prevStore.includes(string)
+          ? [...prevStore, string]
+          : prevStore
       ),
-    size: () => store.size,
   };
 };
 
 export const keyValueStore = createKeyValueStore();
-export const recentEmployeesStore = createRecentEmployeesSet();
+export const recentEmployeesStore = createRecentEmployeesOrderedSet();

--- a/Frontend/src/utils/stores.js
+++ b/Frontend/src/utils/stores.js
@@ -18,23 +18,20 @@ const createKeyValueStore = () => {
   };
 };
 
-const createRecentEmployeesOrderedSet = () => {
-  // a array, that means each value is only included once
-  // however, we overwrite the "add" function to only add
-  // items that are not in the list yet. So it is basically
-  // a Set that is ordered by insertion order
+const createRecentEmployeesArray = () => {
+  // the array will simply keep growing and items will be double.
+  // however we should never run into performance problems
+  // as there are only a couple of dozens of entries created per day
   const store = writable(new Array());
 
   return {
     ...store,
     add: (string) =>
       store.update((prevStore) =>
-        string && !prevStore.includes(string)
-          ? [...prevStore, string]
-          : prevStore
+        string ? [...prevStore, string] : prevStore
       ),
   };
 };
 
 export const keyValueStore = createKeyValueStore();
-export const recentEmployeesStore = createRecentEmployeesOrderedSet();
+export const recentEmployeesStore = createRecentEmployeesArray();


### PR DESCRIPTION
Currently the recentemployeestore is implemented as a `Set`. However, `Set` doesn't garantuee saving the insertion order. For the return button we retrieve the latest inserted employee, which works fine in Chrome most of the times (insertion order kept if everything is upper case). However in corner cases, lower case and on FireFox this doesnt work.

So I changed it to Array. The array just keeps growing with new employee initials. But that should be fine and should likely not impact performance significantly.