### PR TITLE
reintroduce option to mark things "onbackorder"

### DIFF
--- a/Frontend/src/database/WoocommerceClient.js
+++ b/Frontend/src/database/WoocommerceClient.js
@@ -54,7 +54,7 @@ class WoocommerceClient {
 
   _translateItemAttributesForWc(item) {
     const translateStatus = (status) =>
-      status === "reserved" || status === "onbackorder" ? "outofstock" : status;
+      status === "reserved" ? "outofstock" : status;
 
     const hasSynonyms = item.synonyms && item.synonyms.trim().length > 0;
     const hasReturnDateInFuture = item.expected_return_date ? true : false;


### PR DESCRIPTION
Not sure if there was a reason why we filtered out "onbackorder " - if yes, let me know. Else I think it's useful for noting stuff that is in repair.