### PR TITLE
add orange as cell highlight for reserved

### DIFF
--- a/Frontend/src/components/Input/ColorDefs.js
+++ b/Frontend/src/components/Input/ColorDefs.js
@@ -4,6 +4,8 @@ const ColorDefs = Object.freeze({
   HIGHLIGHT_BLUE: "rgb(45, 144, 224)",
   HIGHLIGHT_YELLOW: "rgb(247, 239, 10)",
 
+  ITEM_RESERVED: "rgb(255, 155, 25)",
+
   RENTAL_RETURNED_TODAY_GREEN: "rgb(214, 252, 208)",
   RENTAL_LATE_RED: "rgb(240, 200, 200)",
   RENTAL_TO_RETURN_TODAY_BLUE: "rgb(160, 200, 250)",

--- a/Frontend/src/data/item/columns.js
+++ b/Frontend/src/data/item/columns.js
@@ -1,7 +1,10 @@
 import { saveParseTimestampToString } from "../../utils/utils.js";
 import Database from "../../database/Database";
+import ColorDefs from "../../components/Input/ColorDefs.js";
 
-const backgroundColor = async (customer) => customer.highlight;
+const backgroundColor = async (item) => item.highlight;
+const backgroundColorStatus = async (item) =>
+  item.status == "reserved" ? ColorDefs.ITEM_RESERVED : item.highlight;
 
 function countRentals(item_id) {
   const selectors = [
@@ -95,7 +98,7 @@ export default [
       if (value === "reserved") return "reserviert";
       if (value === "onbackorder") return "nicht verleihbar";
     },
-    backgroundColor,
+    backgroundColor: backgroundColorStatus,
   },
 
   {


### PR DESCRIPTION
This was a feature wished by some of our volunteers: 

* Highlight the status in the `items` tab if it's reserved. This makes it harder to accidentially give out items that are reserved. 

I don't think we need this for any other status, as they either indicate it is not there anway (i.e. cannot be given out accidentially), or is available, so can be given out.

![image](https://user-images.githubusercontent.com/14980558/175345417-b76ae412-079e-4fa9-9642-74cbba62e28b.png)
