### PR TITLE
Add regex filter to ignore accents and umlauts for AutoComplete

### DIFF
--- a/Frontend/src/data/selectors.js
+++ b/Frontend/src/data/selectors.js
@@ -19,7 +19,7 @@ const itemIdStartsWithAndNotDeletedSelector = (searchValue) =>
 const customerAttributeStartsWithIgnoreCaseSelector = (field, searchValue) =>
   Database.selectorBuilder()
     .withField(field)
-    .startsWithIgnoreCase(searchValue)
+    .startsWithIgnoreCaseAndDiacritics(searchValue)
     .withDocType("customer")
     .build();
 

--- a/Frontend/src/database/SelectorBuilder.js
+++ b/Frontend/src/database/SelectorBuilder.js
@@ -4,6 +4,32 @@ class SelectorBuilder {
     this.currentFieldName = "";
   }
 
+  regexIgnoreCaseAndDiactricis(content) {
+    // returns a regex with content that has diacricits ignored
+    let accentGroups = [
+      "aâãäåæ",
+      "eéèêë",
+      "iíìîï",
+      "oóòôõöø",
+      "uúùûü",
+      "cç",
+      "nñ",
+      "yýÿ",
+    ];
+
+    let regex = content;
+    let accentGroup;
+    let accent;
+    for (accentGroup of accentGroups) {
+      for (accent of accentGroup) {
+        if (content.includes(accent)) {
+          regex = regex.replace(accent, `[${accentGroup}]`);
+        }
+      }
+    }
+    return "(?i)" + regex;
+  }
+
   regexIgnoreCase(content) {
     return "(?i)" + content;
   }
@@ -26,6 +52,15 @@ class SelectorBuilder {
     this.selectors.push({
       [this.currentFieldName]: {
         $regex: this.regexIgnoreCase(value),
+      },
+    });
+    return this;
+  }
+
+  startsWithIgnoreCaseAndDiacritics(value) {
+    this.selectors.push({
+      [this.currentFieldName]: {
+        $regex: this.regexIgnoreCaseAndDiactricis("^" + value),
       },
     });
     return this;


### PR DESCRIPTION
![Animation](https://user-images.githubusercontent.com/14980558/182355253-98036b06-3611-447c-b2b5-8a9ed2f445d6.gif)

I added a small routine that replaces all accented characters with a regex that matches their counterparts. The replacement proceduar is highly inefficients and could be solved with a regex itself, but well.. that would take a lot more brain power for me at least.

fixes #483 