### PR TITLE
Sort values in AutoComplete if values are numerical

### DIFF
--- a/Frontend/src/components/Input/AutocompleteInput.svelte
+++ b/Frontend/src/components/Input/AutocompleteInput.svelte
@@ -13,14 +13,14 @@
   export let onlyNumbers = false;
   export let onSelected = () => {};
   export let valueField;
+  export let itemSortFunction;
+  export let localFiltering;
+  export let sortByMatchedKeywords;
+  export let localSorting;
 
   onMount(() =>
     restrictInputToNumbers(document.getElementById(id), onlyNumbers)
   );
-
-  let itemSortFunction = (itemA, itemB, query) => {
-    return itemA.id - itemB.id;
-  };
 </script>
 
 <div class="container">
@@ -47,12 +47,12 @@
     inputId={id}
     {noResultsText}
     {disabled}
-    localSorting={onlyNumbers}
+    {localSorting}
     hideArrow={true}
-    sortByMatchedKeywords={true}
+    {sortByMatchedKeywords}
     {itemSortFunction}
     localSearch={false}
-    localFiltering={onlyNumbers}
+    {localFiltering}
     valueFieldName={valueField}
     selectedItem={{ attr: value }}
     html5autocomplete={false}

--- a/Frontend/src/components/Input/AutocompleteInput.svelte
+++ b/Frontend/src/components/Input/AutocompleteInput.svelte
@@ -1,6 +1,7 @@
 <script>
   import AutoComplete from "simple-svelte-autocomplete";
   import { onMount } from "svelte";
+  import { invalid_attribute_name_character } from "svelte/internal";
   import { restrictInputToNumbers } from "../../actions/RestrictInputToNumbers";
 
   export let noResultsText;
@@ -16,6 +17,10 @@
   onMount(() =>
     restrictInputToNumbers(document.getElementById(id), onlyNumbers)
   );
+
+  let itemSortFunction = (itemA, itemB, query) => {
+    return itemA.id - itemB.id;
+  };
 </script>
 
 <div class="container">
@@ -42,9 +47,12 @@
     inputId={id}
     {noResultsText}
     {disabled}
+    localSorting={onlyNumbers}
     hideArrow={true}
+    sortByMatchedKeywords={true}
+    {itemSortFunction}
     localSearch={false}
-    localFiltering={false}
+    localFiltering={onlyNumbers}
     valueFieldName={valueField}
     selectedItem={{ attr: value }}
     html5autocomplete={false}

--- a/Frontend/src/components/Input/AutocompleteInput.svelte
+++ b/Frontend/src/components/Input/AutocompleteInput.svelte
@@ -1,7 +1,6 @@
 <script>
   import AutoComplete from "simple-svelte-autocomplete";
   import { onMount } from "svelte";
-  import { invalid_attribute_name_character } from "svelte/internal";
   import { restrictInputToNumbers } from "../../actions/RestrictInputToNumbers";
 
   export let noResultsText;

--- a/Frontend/src/data/rental/inputs.js
+++ b/Frontend/src/data/rental/inputs.js
@@ -114,6 +114,29 @@ const showNotificationsForItem = async (item) => {
   }
 };
 
+let sortItemByIdOrName = (itemA, itemB, query) => {
+  // check if itemX exists at all
+  if ((itemA == undefined) | (itemB == undefined)) {
+    return 0;
+  }
+  // if has id and id is numerical compare id
+  if (
+    (itemA.id !== undefined) &
+    (itemB.id !== undefined) &
+    !(isNaN(itemA.id) | isNaN(itemB.id))
+  ) {
+    return itemA.id - itemB.id;
+  }
+
+  // maybe itemA and itemB themselve are numerical?
+  if (!(isNaN(itemA) | isNaN(itemB))) {
+    return itemA - itemB;
+  }
+
+  // inputs are not numerically sortable
+  return 0;
+};
+
 const showNotificationsForCustomer = async (customerId) => {
   Database.fetchAllDocsBySelector(
     activeRentalsForCustomerSelector(customerId),
@@ -234,6 +257,10 @@ export default {
       component: AutocompleteInput,
       nobind: true,
       props: {
+        localSorting: true,
+        sortByMatchedKeywords: true,
+        itemSortFunction: () => sortItemByIdOrName,
+        localFiltering: true,
         valueField: "id",
         onlyNumbers: true,
         searchFunction: (context) => (searchTerm) =>
@@ -346,6 +373,10 @@ export default {
       component: AutocompleteInput,
       nobind: true,
       props: {
+        localSorting: true,
+        sortByMatchedKeywords: true,
+        itemSortFunction: () => sortItemByIdOrName,
+        localFiltering: true,
         valueField: "id",
         onlyNumbers: true,
         searchFunction: (context) => (searchTerm) =>

--- a/Frontend/src/data/rental/inputs.js
+++ b/Frontend/src/data/rental/inputs.js
@@ -114,7 +114,7 @@ const showNotificationsForItem = async (item) => {
   }
 };
 
-let sortItemByIdOrName = (itemA, itemB, query) => {
+let sortItemByIdOrName = (itemA, itemB) => {
   // check if itemX exists at all
   if ((itemA == undefined) | (itemB == undefined)) {
     return 0;
@@ -260,7 +260,6 @@ export default {
         localSorting: true,
         sortByMatchedKeywords: true,
         itemSortFunction: () => sortItemByIdOrName,
-        localFiltering: true,
         valueField: "id",
         onlyNumbers: true,
         searchFunction: (context) => (searchTerm) =>


### PR DESCRIPTION
This solves the problem of the prepended zeros. Values inside AutoComplete are sorted based on their `id` if numerical values are expected

fixes #471

![Animation](https://user-images.githubusercontent.com/14980558/182393805-3f9b0598-e289-4bb8-8cea-97617ef059fc.gif)

The docs are a bit unclear which flags exactly need to be `true` for this to work, but with the current flags it seems to do its job, i.e.,

```
localSorting={onlyNumbers}
sortByMatchedKeywords={true}
localFiltering={onlyNumbers}
```