### PR TITLE
don't filter text, make special chars searchable

### DIFF
--- a/Frontend/src/components/Input/AutocompleteInput.svelte
+++ b/Frontend/src/components/Input/AutocompleteInput.svelte
@@ -22,7 +22,7 @@
   <AutoComplete
     delay={150}
     {searchFunction}
-    textCleanFunction={(text) => (value = text)}
+    cleanUserText={onlyNumbers}
     labelFunction={(item) => {
       if (typeof item === "undefined") return "";
       const values = Object.values(item);

--- a/Frontend/src/components/Input/AutocompleteInput.svelte
+++ b/Frontend/src/components/Input/AutocompleteInput.svelte
@@ -22,7 +22,9 @@
   <AutoComplete
     delay={150}
     {searchFunction}
+    textCleanFunction={(text) => (value = text)}
     cleanUserText={onlyNumbers}
+    
     labelFunction={(item) => {
       if (typeof item === "undefined") return "";
       const values = Object.values(item);


### PR DESCRIPTION
By disabling `cleanUserText` in `AutoComplete` it would be possible to search for anything containing special characters, e.g. `D'Angelo`.

![Animation](https://user-images.githubusercontent.com/14980558/182402661-2ae6eca0-44fb-41d1-8108-d2f90a84672f.gif)


Fixes #468

I think this should be rather safe. The data is already in the database. We do not perform any sanitation while creating the users or items. So insertion via `AutoComplete` cannot do any more harm than this anyway.