### PR TITLE
add field for internal notes

### DIFF
--- a/Frontend/src/data/item/inputs.js
+++ b/Frontend/src/data/item/inputs.js
@@ -226,5 +226,14 @@ export default {
         disabled: isDeleted,
       },
     },
+    {
+      id: "internal_note",
+      label: "Interne Notiz",
+      group: "Status",
+      component: TextInput,
+      props: {
+        multiline: true,
+      },
+    },
   ],
 };


### PR DESCRIPTION
Adds a new field for internal notes on items as requested by Chris and Luna. These notes are only shown when editing an item.


![image](https://user-images.githubusercontent.com/9028156/185781985-fc7b8b43-979a-4367-8976-333a22e60dda.png)
