### PR TITLE
fix item available but has return date

### DIFF
--- a/Frontend/src/database/WoocommerceClient.js
+++ b/Frontend/src/database/WoocommerceClient.js
@@ -58,7 +58,7 @@ class WoocommerceClient {
 
     const hasSynonyms = item.synonyms && item.synonyms.trim().length > 0;
     const isAvailableAndHasReturnDateInFuture =
-      item.expected_return_date && item.status != "instock" ? true : false;
+      item.expected_return_date && item.status == "outofstock" ? true : false;
 
     return {
       name: item.name,

--- a/Frontend/src/database/WoocommerceClient.js
+++ b/Frontend/src/database/WoocommerceClient.js
@@ -57,7 +57,8 @@ class WoocommerceClient {
       status === "reserved" ? "outofstock" : status;
 
     const hasSynonyms = item.synonyms && item.synonyms.trim().length > 0;
-    const hasReturnDateInFuture = item.expected_return_date ? true : false;
+    const isAvailableAndHasReturnDateInFuture =
+      item.expected_return_date && item.status != "instock" ? true : false;
 
     return {
       name: item.name,
@@ -97,7 +98,9 @@ class WoocommerceClient {
         },
         {
           key: "zuruckerwartet",
-          value: hasReturnDateInFuture ? item.expected_return_date : "",
+          value: isAvailableAndHasReturnDateInFuture
+            ? item.expected_return_date
+            : "",
         },
       ],
     };

--- a/Frontend/src/database/WoocommerceClient.js
+++ b/Frontend/src/database/WoocommerceClient.js
@@ -57,7 +57,7 @@ class WoocommerceClient {
       status === "reserved" ? "outofstock" : status;
 
     const hasSynonyms = item.synonyms && item.synonyms.trim().length > 0;
-    const isAvailableAndHasReturnDateInFuture =
+    const isRentedAndHasReturnDateInFuture =
       item.expected_return_date && item.status == "outofstock" ? true : false;
 
     return {
@@ -98,7 +98,7 @@ class WoocommerceClient {
         },
         {
           key: "zuruckerwartet",
-          value: isAvailableAndHasReturnDateInFuture
+          value: isRentedAndHasReturnDateInFuture
             ? item.expected_return_date
             : "",
         },

--- a/Frontend/src/database/WoocommerceClientMock.js
+++ b/Frontend/src/database/WoocommerceClientMock.js
@@ -34,13 +34,13 @@ class WoocommerceClientMock {
   }
 
   _translateItemAttributesForWc(item) {
-    const isAvailableAndHasReturnDateInFuture =
+    const isRentedAndHasReturnDateInFuture =
       item.expected_return_date && item.status == "outofstock" ? true : false;
 
     console.log(
       "expected return date",
       item.expected_return_date,
-      isAvailableAndHasReturnDateInFuture
+      isRentedAndHasReturnDateInFuture
     );
   }
 

--- a/Frontend/src/database/WoocommerceClientMock.js
+++ b/Frontend/src/database/WoocommerceClientMock.js
@@ -34,7 +34,14 @@ class WoocommerceClientMock {
   }
 
   _translateItemAttributesForWc(item) {
-    console.log(item.expected_return_date);
+    const isAvailableAndHasReturnDateInFuture =
+      item.expected_return_date && item.status != "instock" ? true : false;
+
+    console.log(
+      "expected return date",
+      item.expected_return_date,
+      isAvailableAndHasReturnDateInFuture
+    );
   }
 
   async updateItem(item) {

--- a/Frontend/src/database/WoocommerceClientMock.js
+++ b/Frontend/src/database/WoocommerceClientMock.js
@@ -35,7 +35,7 @@ class WoocommerceClientMock {
 
   _translateItemAttributesForWc(item) {
     const isAvailableAndHasReturnDateInFuture =
-      item.expected_return_date && item.status != "instock" ? true : false;
+      item.expected_return_date && item.status == "outofstock" ? true : false;
 
     console.log(
       "expected return date",


### PR DESCRIPTION
fixes #495 

simple fix: if item.status is not `outofstock`, ie. item is currently rented, then no estimated return date can be displayed.